### PR TITLE
Supporting policy property update in `authenticateWithSuccess`

### DIFF
--- a/Authenticator-ObjC/EHFAuthenticator.m
+++ b/Authenticator-ObjC/EHFAuthenticator.m
@@ -58,8 +58,9 @@ static EHFAuthenticator *sharedInstance;
     }else if (self.hideFallbackButton){
         self.context.localizedFallbackTitle = @"";
     }
-    if ([self.context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError]) {
-        [self.context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+    
+    if ([self.context canEvaluatePolicy: self.policy error:&authError]) {
+        [self.context evaluatePolicy: self.policy
                      localizedReason:self.reason
                                reply:^(BOOL authenticated, NSError *error) {
                                    if (authenticated) {


### PR DESCRIPTION
Fixed issue [#9](https://github.com/jstart/EHFAuthenticator-Touch-ID/issues/9)